### PR TITLE
[codex] Restore Fshare download flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,10 @@ Since I can not find any working script for my headless Sheevaplug / Raspberry P
 ![alt text](https://github.com/haindvn/FShareDownloader/blob/master/screenshot3.JPG)
 
 ## Required packages:
-* Pyhon 3.5+
+* Python 3.8+
 * lxml (for Debian system, please install python3-lxml package, we don't need pip to compile from source)
 * requests
-* get_fshare
-* requests
-* hyper
+* httpx with HTTP/2 support
 * colorama
 * termcolor 
 * tqdm
@@ -23,7 +21,7 @@ Since I can not find any working script for my headless Sheevaplug / Raspberry P
 In short, please run these commands on Debian system to install the neccessary packages
 ```
 $ sudo apt-get install python3-lxml
-$ sudo pip3 install get_fshare requests hyper colorama termcolor tqdm
+$ sudo pip3 install 'httpx[http2]' requests colorama termcolor tqdm
 ```
 
 ## Getting Started / Usage
@@ -53,6 +51,6 @@ Then a folder `XXXXXXXXXX` will be created in `/home/haind/movies` then all file
 
 **Note**: if there are sub-folders in the folder link, **they will be skipped, ONLY FILES IN THE FOLDER WILL BE DOWNLOADED**, the script will not recursively download any sub-folder to avoid uncontrollable linked folders/files. The script will also write down a short text file with some useful information for later reference later. 
 
-All credits goes to [FShare API](https://github.com/tudoanh/get_fshare)
+The current version uses Fshare's web metadata API directly because the old `get_fshare` file metadata endpoint no longer returns reliable JSON.
 
 Enjoy Downloading !!!

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ sudo pip3 install 'httpx[http2]' requests colorama termcolor tqdm
 
 * Download / clone or fork this repo
 * Update `credentials.ini` with your `FShare username` / `password`
+* For full-speed web downloads, export cookies from a logged-in `www.fshare.vn` browser session and set `cookie_file` in `credentials.ini`. When `cookie_file` is set, `username` and `password` are optional.
 * Download file or whole folder from FShare by running this command
 ```
 python3 fdownload.py <file or folder URL> <path_to_save>
@@ -49,8 +50,14 @@ $ python3 fdownload.py https://www.fshare.vn/folder/XXXXXXXX /home/haind/movies
 ```
 Then a folder `XXXXXXXXXX` will be created in `/home/haind/movies` then all files will be put in `XXXXXXXXXX` (we won't create a folder basing on the folder name as per FShare's folder name since I found folder name with Vietnamese accent will be corrupted or give some ab-normal disk operations later, please change the folder name by yourself)
 
+**Cookie login example**
+```
+cookie_file=/home/haind/www.fshare.vn_cookies.json
+```
+Keep this cookie file private because it contains your logged-in Fshare session.
+
 **Note**: if there are sub-folders in the folder link, **they will be skipped, ONLY FILES IN THE FOLDER WILL BE DOWNLOADED**, the script will not recursively download any sub-folder to avoid uncontrollable linked folders/files. The script will also write down a short text file with some useful information for later reference later. 
 
-The current version uses Fshare's web metadata API directly because the old `get_fshare` file metadata endpoint no longer returns reliable JSON.
+The current version uses Fshare's web metadata API directly because the old `get_fshare` file metadata endpoint no longer returns reliable JSON. If `cookie_file` is configured, download links are created through Fshare's web download flow; otherwise the legacy API download flow is used as a fallback.
 
 Enjoy Downloading !!!

--- a/fdownload.py
+++ b/fdownload.py
@@ -4,32 +4,192 @@ from __future__ import print_function
 #from apiclient import errors
 from colorama import init,Fore,Back,Style
 from termcolor import colored
-from get_fshare import FSAPI
 from tqdm import tqdm
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, RequestException, Timeout
 
-import configparser 
+import configparser
+import httpx
 import os
 import sys
 import requests
 import re
+from urllib.parse import parse_qs, urlparse
 
-# Requires: get_fshare requests  lxml  hyper apiclient colorama termcolor tqdm
+# Requires: httpx[http2] requests colorama termcolor tqdm
 # Debian package: python3-lxml
 # libxml2 libxslt
 
 # Main FShare URLs
 FShare_File_URL = 'https://www.fshare.vn/file/'
 FShare_Folder_URL = 'https://www.fshare.vn/folder/'
+FShare_Web_URL = 'https://www.fshare.vn'
+FShare_API_URL = 'https://api.fshare.vn/api'
 re_folder_pattern = r"(https://www\.fshare\.vn/folder/)([^\?]+)(?:(\?.*))?"
 re_folder_name_pattern = r"(.*/)(.*)"
 File_Indicator = '/file/'
 Folder_Indicator = '/folder/'
 Folder_Reference_Filename = "Folder_Information.txt"
+FShare_App_Key = "L2S7R6ZMagggC5wWkQhX2+aDi467PPuftWUMRFSn"
 
 CONFIG_FILE = "credentials.ini"
 
 service=''
+
+class FShareAPIError(Exception):
+    pass
+
+
+class FSAPI:
+    """
+    Small Fshare client for the endpoints this downloader needs.
+
+    The old get_fshare fileops metadata endpoints now often return HTML/empty
+    responses. The web v3 metadata endpoint still returns JSON, while the old
+    HTTP/2 session/download endpoint still creates the direct download link.
+    """
+
+    def __init__(self, email, password):
+        self.email = email
+        self.password = password
+        self.token = ""
+        self.session_id = ""
+        self.api = httpx.Client(
+            http2=True,
+            timeout=30.0,
+            headers={"User-Agent": "okhttp/3.6.0"},
+        )
+        self.web = requests.Session()
+        self.web.headers.update({
+            "User-Agent": (
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+            )
+        })
+
+    def login(self):
+        payload = {
+            "user_email": self.email,
+            "password": self.password,
+            "app_key": FShare_App_Key,
+        }
+        response = self.api.post(f"{FShare_API_URL}/user/login/", json=payload)
+        data = self._httpx_json(response, "login")
+        if data.get("code") != 200:
+            raise FShareAPIError(data.get("msg", "Login failed"))
+
+        self.token = data["token"]
+        self.session_id = data["session_id"]
+        self.api.cookies.set("session_id", self.session_id, domain="api.fshare.vn")
+        return data
+
+    def download(self, url, password=None):
+        url = self.check_valid(url)
+        payload = {"token": self.token, "url": url}
+        if password:
+            payload["password"] = password
+
+        response = self.api.post(f"{FShare_API_URL}/session/download", json=payload)
+        data = self._httpx_json(response, "download session")
+        if response.status_code == 403:
+            raise FShareAPIError("Password invalid")
+        if response.status_code != 200 or "location" not in data:
+            raise FShareAPIError(data.get("msg", "Could not create download link"))
+        return data["location"]
+
+    def get_file_info(self, url):
+        linkcode = self._linkcode_from_url(url)
+        data = self._get_v3_linkcode(linkcode)
+        info = data.get("current")
+        if not info:
+            raise FShareAPIError("Could not find file information")
+        return self._normalize_item(info)
+
+    def get_folder_urls(self, url):
+        linkcode = self._linkcode_from_url(url)
+        items = []
+        page = 1
+        last_page = 1
+
+        while page <= last_page:
+            data = self._get_v3_linkcode(linkcode, page=page)
+            items.extend(self._normalize_item(item) for item in data.get("items", []))
+            last_page = max(last_page, self._last_page_from_links(data.get("_links", {})))
+            page += 1
+
+        return items
+
+    def check_valid(self, url):
+        parsed = urlparse(url)
+        if parsed.netloc not in ("www.fshare.vn", "fshare.vn"):
+            raise FShareAPIError("Must be Fshare url")
+        clean_path = parsed.path.rstrip("/")
+        return f"{FShare_Web_URL}{clean_path}"
+
+    def _get_v3_linkcode(self, linkcode, page=1):
+        response = self.web.get(
+            f"{FShare_Web_URL}/api/v3/files/folder",
+            params={
+                "linkcode": linkcode,
+                "sort": "type,name",
+                "page": page,
+                "per-page": 50,
+                "details": "true",
+            },
+            timeout=30,
+        )
+        data = self._requests_json(response, "metadata lookup")
+        if response.status_code != 200:
+            message = data.get("message") or data.get("name") or "Metadata lookup failed"
+            raise FShareAPIError(f"{message} ({response.status_code})")
+        return data
+
+    def _normalize_item(self, item):
+        normalized = dict(item)
+        item_type = int(normalized.get("type", normalized.get("file_type", 1)))
+        normalized["file_type"] = item_type
+        normalized["furl"] = (
+            FShare_Folder_URL if item_type == 0 else FShare_File_URL
+        ) + normalized["linkcode"]
+        return normalized
+
+    def _linkcode_from_url(self, url):
+        parsed = urlparse(url)
+        path_parts = [part for part in parsed.path.split("/") if part]
+        if len(path_parts) >= 2 and path_parts[0] in ("file", "folder"):
+            return path_parts[1]
+        if not parsed.netloc and url.strip():
+            return url.strip().split("?")[0].strip("/")
+        raise FShareAPIError("Could not read Fshare linkcode from URL")
+
+    def _last_page_from_links(self, links):
+        last = links.get("last") or links.get("self") or ""
+        page = parse_qs(urlparse(last).query).get("page", ["1"])[0]
+        try:
+            return int(page)
+        except ValueError:
+            return 1
+
+    def _httpx_json(self, response, action):
+        try:
+            return response.json()
+        except ValueError:
+            snippet = response.text.strip().replace("\n", " ")[:200]
+            raise FShareAPIError(
+                f"Fshare {action} returned non-JSON response "
+                f"({response.status_code} {response.headers.get('content-type')}): "
+                f"{snippet or '<empty>'}"
+            )
+
+    def _requests_json(self, response, action):
+        try:
+            return response.json()
+        except ValueError:
+            snippet = response.text.strip().replace("\n", " ")[:200]
+            raise FShareAPIError(
+                f"Fshare {action} returned non-JSON response "
+                f"({response.status_code} {response.headers.get('content-type')}): "
+                f"{snippet or '<empty>'}"
+            )
 
 
 def main():
@@ -68,10 +228,19 @@ def main():
     # Check file or folder
     if not is_folder(downloadID):
         # It's a file, download it now
-        fileInfo = service.get_file_info(downloadID)
+        try:
+            fileInfo = service.get_file_info(downloadID)
+        except FShareAPIError as e:
+            print(colored('Could not get file information: {}'.format(e),'red'))
+            exit(1)
         print(colored('File: ','white'),colored('{}'.format(fileInfo['name']),'yellow'))
         # print(f'Saving to {location}')
-        download_file(service.download(FShare_File_URL+fileInfo['linkcode']),location,fileInfo['name'])
+        try:
+            download_url = service.download(FShare_File_URL+fileInfo['linkcode'])
+        except FShareAPIError as e:
+            print(colored('Could not create download link: {}'.format(e),'red'))
+            exit(1)
+        download_file(download_url,location,fileInfo['name'])
         print(colored('{} downloaded'.format(fileInfo['name']),'yellow'))
 
     elif is_folder(downloadID):
@@ -96,7 +265,11 @@ def download_folder(url, location):
         print(colored("Folder Link error, please make sure it's welformed as https://www.fshare.vn/folder/XXXXXXXXXX (token trail is optional)",'red'))
         return 1
     
-    folderList = service.get_folder_urls(url)
+    try:
+        folderList = service.get_folder_urls(url)
+    except FShareAPIError as e:
+        print(colored("Could not get folder information: {}".format(e),'red'))
+        return 1
     if (len(folderList)) < 1:
         print("Folder empty!")
         return 1
@@ -132,7 +305,12 @@ def download_folder(url, location):
     for fileInfo in folderList:
         if not is_folder(fileInfo['furl']):
             print(colored('File #{}: '.format(fileCount),'white'),colored('{}'.format(fileInfo['name']),'yellow'))
-            download_file(service.download(FShare_File_URL+fileInfo['linkcode']),location,fileInfo['name'])
+            try:
+                download_url = service.download(FShare_File_URL+fileInfo['linkcode'])
+            except FShareAPIError as e:
+                print(colored('Could not create download link for {}: {}'.format(fileInfo['name'], e),'red'))
+                continue
+            download_file(download_url,location,fileInfo['name'])
             fileCount += 1
     
 def download_file(url, location,filename):
@@ -147,17 +325,17 @@ def download_file(url, location,filename):
         return 1
     else:
         try:
-            with requests.get(url, stream=True,timeout=(2,3)) as r:
+            with requests.get(url, stream=True,timeout=(10,30)) as r:
                 try:
                     r.raise_for_status()
-                    total_size = int(r.headers.get('content-length'))
+                    total_size = int(r.headers.get('content-length') or 0)
                     if (total_size > (2*1024*1024*1024)):
                     #File is greater than 2Gb, use bigger chunk size
                         download_chunk_size = 2*1024*1024
                     else:
                         download_chunk_size = 1024*1024
                     downloaded_chunk = 0
-                    progressbar = tqdm(total=total_size,desc="Downloading",ncols=70, unit_scale=True, unit="B")
+                    progressbar = tqdm(total=total_size or None,desc="Downloading",ncols=70, unit_scale=True, unit="B")
                     with open(location + local_filename, 'wb') as f:
                         for chunk in r.iter_content(chunk_size=download_chunk_size): 
                             if chunk: # filter out keep-alive new chunks
@@ -172,6 +350,8 @@ def download_file(url, location,filename):
             return (location + local_filename)
         except Timeout:
             print('Please check Internet connection, the request timed out')
+        except RequestException as e:
+            print('Download failed: {}'.format(e))
         
         
 def is_folder(url):
@@ -189,7 +369,7 @@ def perform_login(login_credential):
     login_status = True
     try:
         service.login()
-    except KeyError:
+    except (KeyError, FShareAPIError, httpx.HTTPError):
         login_status=False
     return login_status
 
@@ -215,18 +395,18 @@ def splash_screen():
     cls()
 
 
-    print(colored('_______      _______. __    __       ___      .______       _______     ____    ____ .__   __.                     ', 'red'))
-    print(colored('|   ____|    /       ||  |  |  |     /   \     |   _  \     |   ____|    \   \  /   / |  \ |  |                    ', 'red'))
-    print(colored('|  |__      |   (----`|  |__|  |    /  ^  \    |  |_)  |    |  |__        \   \/   /  |   \|  |                    ', 'red')) 
-    print(colored('|   __|      \   \    |   __   |   /  /_\  \   |      /     |   __|        \      /   |  . `  |                    ', 'yellow'))
-    print(colored('|  |     .----)   |   |  |  |  |  /  _____  \  |  |\  \----.|  |____  __    \    /    |  |\   |                    ', 'yellow'))
-    print(colored('|__|     |_______/    |__|  |__| /__/     \__\ | _| `._____||_______|(__)    \__/     |__| \__|                    ', 'green'))
-    print(colored('_______   ______   ____    __    ____ .__   __.  __        ______        ___       _______   _______ .______       ', 'blue'))
-    print(colored('|       \ /  __  \  \   \  /  \  /   / |  \ |  | |  |      /  __  \      /   \     |       \ |   ____||   _  \     ', 'blue'))
-    print(colored('|  .--.  |  |  |  |  \   \/    \/   /  |   \|  | |  |     |  |  |  |    /  ^  \    |  .--.  ||  |__   |  |_)  |    ', 'magenta'))
-    print(colored('|  |  |  |  |  |  |   \            /   |  . `  | |  |     |  |  |  |   /  /_\  \   |  |  |  ||   __|  |      /     ', 'magenta'))
-    print(colored("|  '--'  |  `--'  |    \    /\    /    |  |\   | |  `----.|  `--'  |  /  _____  \  |  '--'  ||  |____ |  |\  \----.", 'cyan'))
-    print(colored('|_______/ \______/      \__/  \__/     |__| \__| |_______| \______/  /__/     \__\ |_______/ |_______|| _| `._____|', 'cyan'))
+    print(colored(r'_______      _______. __    __       ___      .______       _______     ____    ____ .__   __.                     ', 'red'))
+    print(colored(r'|   ____|    /       ||  |  |  |     /   \     |   _  \     |   ____|    \   \  /   / |  \ |  |                    ', 'red'))
+    print(colored(r'|  |__      |   (----`|  |__|  |    /  ^  \    |  |_)  |    |  |__        \   \/   /  |   \|  |                    ', 'red'))
+    print(colored(r'|   __|      \   \    |   __   |   /  /_\  \   |      /     |   __|        \      /   |  . `  |                    ', 'yellow'))
+    print(colored(r'|  |     .----)   |   |  |  |  |  /  _____  \  |  |\  \----.|  |____  __    \    /    |  |\   |                    ', 'yellow'))
+    print(colored(r'|__|     |_______/    |__|  |__| /__/     \__\ | _| `._____||_______|(__)    \__/     |__| \__|                    ', 'green'))
+    print(colored(r'_______   ______   ____    __    ____ .__   __.  __        ______        ___       _______   _______ .______       ', 'blue'))
+    print(colored(r'|       \ /  __  \  \   \  /  \  /   / |  \ |  | |  |      /  __  \      /   \     |       \ |   ____||   _  \     ', 'blue'))
+    print(colored(r'|  .--.  |  |  |  |  \   \/    \/   /  |   \|  | |  |     |  |  |  |    /  ^  \    |  .--.  ||  |__   |  |_)  |    ', 'magenta'))
+    print(colored(r'|  |  |  |  |  |  |   \            /   |  . `  | |  |     |  |  |  |   /  /_\  \   |  |  |  ||   __|  |      /     ', 'magenta'))
+    print(colored(r"|  '--'  |  `--'  |    \    /\    /    |  |\   | |  `----.|  `--'  |  /  _____  \  |  '--'  ||  |____ |  |\  \----.", 'cyan'))
+    print(colored(r'|_______/ \______/      \__/  \__/     |__| \__| |_______| \______/  /__/     \__\ |_______/ |_______|| _| `._____|', 'cyan'))
     print(colored('===================================================================================================================', 'white'))
     print(colored('                                                                             Version : ', 'yellow'), (1.0))
     print(colored('                                                                              Author : ', 'yellow'), ('haind'))

--- a/fdownload.py
+++ b/fdownload.py
@@ -8,13 +8,16 @@ from tqdm import tqdm
 from requests.exceptions import HTTPError, RequestException, Timeout
 
 import configparser
+import gc
 import httpx
 import json
 import os
 import sys
 import requests
 import re
-from urllib.parse import parse_qs, urlparse
+import time
+from urllib.parse import parse_qs, urljoin, urlparse
+from requests.adapters import HTTPAdapter
 
 # Requires: httpx[http2] requests colorama termcolor tqdm
 # Debian package: python3-lxml
@@ -33,6 +36,10 @@ Folder_Reference_Filename = "Folder_Information.txt"
 FShare_App_Key = "L2S7R6ZMagggC5wWkQhX2+aDi467PPuftWUMRFSn"
 
 CONFIG_FILE = "credentials.ini"
+TRAFFIC_CHECK_INTERVAL_SECONDS = 10 * 60
+LOW_SPEED_THRESHOLD_BYTES = 256 * 1024
+LOW_SPEED_GRACE_SECONDS = 120
+LOW_SPEED_WINDOW_SECONDS = 60
 
 service=''
 
@@ -54,6 +61,7 @@ class FSAPI:
         self.password = password
         self.cookie_file = None
         self.web_download = False
+        self.download_traffic = None
         self.token = ""
         self.session_id = ""
         self.api = httpx.Client(
@@ -62,11 +70,16 @@ class FSAPI:
             headers={"User-Agent": "okhttp/3.6.0"},
         )
         self.web = requests.Session()
+        adapter = HTTPAdapter(pool_connections=2, pool_maxsize=2, pool_block=True)
+        self.web.mount("https://", adapter)
+        self.web.mount("http://", adapter)
         self.web.headers.update({
             "User-Agent": (
                 "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
                 "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
-            )
+            ),
+            "Accept-Encoding": "identity",
+            "Connection": "close",
         })
 
     def use_cookie_file(self, cookie_file):
@@ -167,34 +180,51 @@ class FSAPI:
         form = re.search(r'<form id="form-download".*?</form>', response.text, re.S)
         if not form:
             raise FShareAPIError("Could not find Fshare download form. Cookie may be expired.")
-        csrf = re.search(r'name="_csrf-app" value="([^"]+)"', form.group(0))
-        linkcode = re.search(r'name="linkcode" value="([^"]+)"', form.group(0))
+        form_html = form.group(0)
+        payload = self._form_payload(form_html)
+        csrf = payload.get("_csrf-app")
+        linkcode = payload.get("linkcode") or payload.get("linkcodeDownload")
         if not csrf or not linkcode:
             raise FShareAPIError("Could not read Fshare download form fields")
 
-        payload = {
-            "_csrf-app": csrf.group(1),
-            "linkcode": linkcode.group(1),
-            "ushare": "",
-            "withFcode5": "0",
-        }
+        payload["linkcode"] = linkcode
+        payload.setdefault("ushare", "")
+        payload["withFcode5"] = "0"
+        action = re.search(r'action="([^"]+)"', form_html)
+        download_endpoint = urljoin(FShare_Web_URL, action.group(1)) if action else f"{FShare_Web_URL}/download/get"
+        data = self._post_web_download(download_endpoint, url, payload)
+        if data.get("policydowload") and "url" not in data:
+            payload["slow_download"] = "1"
+            data = self._post_web_download(download_endpoint, url, payload)
+        if "url" not in data:
+            message = data.get("message") or data.get("errors") or data
+            raise FShareAPIError(f"Could not create web download link: {message}")
+        return data["url"]
+
+    def _post_web_download(self, endpoint, referer, payload):
         try:
             response = self.web.post(
-                f"{FShare_Web_URL}/download/get",
+                endpoint,
                 data=payload,
                 headers={
                     "X-Requested-With": "XMLHttpRequest",
-                    "Referer": url,
+                    "Referer": referer,
                 },
                 timeout=30,
             )
         except RequestException as e:
             raise FShareAPIError(f"Could not create web download session: {e}")
-        data = self._requests_json(response, "web download session")
-        if "url" not in data:
-            message = data.get("message") or data.get("errors") or data
-            raise FShareAPIError(f"Could not create web download link: {message}")
-        return data["url"]
+        return self._requests_json(response, "web download session")
+
+    def _form_payload(self, form_html):
+        payload = {}
+        for field in re.finditer(r'<input\b[^>]*>', form_html, re.S):
+            name = re.search(r'\bname="([^"]+)"', field.group(0))
+            if not name:
+                continue
+            value = re.search(r'\bvalue="([^"]*)"', field.group(0))
+            payload[name.group(1)] = value.group(1) if value else ""
+        return payload
 
     def _load_web_cookies(self, cookie_file):
         with open(cookie_file) as f:
@@ -217,6 +247,107 @@ class FSAPI:
         response.raise_for_status()
         if "LoginForm[email]" in response.text or "/site/login" in response.url:
             raise FShareAPIError("Fshare cookie is expired or not logged in")
+
+    def get_download_traffic(self):
+        if not self.web_download:
+            return None
+        response = self.web.get(f"{FShare_Web_URL}/account/inforesource", timeout=30)
+        response.raise_for_status()
+        if "LoginForm[email]" in response.text or "/site/login" in response.url:
+            raise FShareAPIError("Fshare cookie is expired or not logged in")
+        chart = re.search(
+            r"Highcharts\.chart\('container-traffic-download'.*?"
+            r"\['Còn khả dụng',\s*(\d+)\],\s*\['Đã sử dụng',\s*(\d+)\]",
+            response.text,
+            re.S,
+        )
+        if chart:
+            remaining_bytes = int(chart.group(1))
+            used_bytes = int(chart.group(2))
+            total_bytes = used_bytes + remaining_bytes
+            return {
+                "used": self._bytes_to_traffic(used_bytes),
+                "total": self._bytes_to_traffic(total_bytes),
+                "remaining": self._bytes_to_traffic(remaining_bytes),
+                "percent": (used_bytes / total_bytes * 100) if total_bytes else 0,
+                "used_bytes": used_bytes,
+                "total_bytes": total_bytes,
+                "remaining_bytes": remaining_bytes,
+            }
+        match = re.search(
+            r'<li class="mdc-list-item download-traffic"[^>]*>.*?<p>\s*'
+            r'<a[^>]*>.*?</a>\s*([^<]+?)\s*/\s*([^<]+?)\s*</p>.*?'
+            r'scaleX\(([^)]+)\)',
+            response.text,
+            re.S,
+        )
+        if not match:
+            return None
+        used = " ".join(match.group(1).split())
+        total = " ".join(match.group(2).split())
+        ratio = float(match.group(3))
+        return {
+            "used": used,
+            "total": total,
+            "remaining": self._traffic_remaining(used, total),
+            "percent": ratio * 100,
+            "used_bytes": self._traffic_to_bytes(used),
+            "total_bytes": self._traffic_to_bytes(total),
+            "remaining_bytes": self._traffic_remaining_bytes(used, total),
+        }
+
+    def _traffic_remaining(self, used, total):
+        remaining_bytes = self._traffic_remaining_bytes(used, total)
+        if remaining_bytes is None:
+            return None
+        return self._bytes_to_traffic(remaining_bytes)
+
+    def _traffic_remaining_bytes(self, used, total):
+        used_bytes = self._traffic_to_bytes(used)
+        total_bytes = self._traffic_to_bytes(total)
+        if used_bytes is None or total_bytes is None:
+            return None
+        return max(total_bytes - used_bytes, 0)
+
+    def refresh_download_traffic(self):
+        self.download_traffic = self.get_download_traffic()
+        return self.download_traffic
+
+    def apply_download_traffic_usage(self, downloaded_bytes):
+        if not self.download_traffic or "remaining_bytes" not in self.download_traffic:
+            return
+        used_bytes = (self.download_traffic.get("used_bytes") or 0) + downloaded_bytes
+        total_bytes = self.download_traffic.get("total_bytes") or used_bytes
+        remaining_bytes = max(total_bytes - used_bytes, 0)
+        self.download_traffic.update({
+            "used": self._bytes_to_traffic(used_bytes),
+            "total": self._bytes_to_traffic(total_bytes),
+            "remaining": self._bytes_to_traffic(remaining_bytes),
+            "percent": (used_bytes / total_bytes * 100) if total_bytes else 0,
+            "used_bytes": used_bytes,
+            "total_bytes": total_bytes,
+            "remaining_bytes": remaining_bytes,
+        })
+
+    def is_download_traffic_low(self, file_size):
+        if not self.download_traffic or file_size <= 0:
+            return False
+        remaining_bytes = self.download_traffic.get("remaining_bytes")
+        return remaining_bytes is not None and remaining_bytes < file_size
+
+    def _traffic_to_bytes(self, value):
+        match = re.search(r'([\d.]+)\s*([KMGT]?B)', value, re.I)
+        if not match:
+            return None
+        units = {"B": 1, "KB": 1024, "MB": 1024 ** 2, "GB": 1024 ** 3, "TB": 1024 ** 4}
+        return float(match.group(1)) * units[match.group(2).upper()]
+
+    def _bytes_to_traffic(self, value):
+        for unit in ("TB", "GB", "MB", "KB"):
+            factor = {"KB": 1024, "MB": 1024 ** 2, "GB": 1024 ** 3, "TB": 1024 ** 4}[unit]
+            if value >= factor:
+                return "{:.1f} {}".format(value / factor, unit)
+        return "{} B".format(int(value))
 
     def _normalize_item(self, item):
         normalized = dict(item)
@@ -276,6 +407,7 @@ def main():
 
     if login_status:
         print(colored('Logged in successfully!','white'))
+        print_download_traffic()
     else:
         print(colored('Login failed! Please check login credentials in {}'.format(CONFIG_FILE),'white'))
         print(colored('Quit','white'))
@@ -310,12 +442,12 @@ def main():
             exit(1)
         print(colored('File: ','white'),colored('{}'.format(fileInfo['name']),'yellow'))
         # print(f'Saving to {location}')
+        file_url = FShare_File_URL+fileInfo['linkcode']
         try:
-            download_url = service.download(FShare_File_URL+fileInfo['linkcode'])
+            download_file(file_url,location,fileInfo['name'],fileInfo.get('size') or fileInfo.get('file_size'))
         except FShareAPIError as e:
             print(colored('Could not create download link: {}'.format(e),'red'))
             exit(1)
-        download_file(download_url,location,fileInfo['name'])
         print(colored('{} downloaded'.format(fileInfo['name']),'yellow'))
 
     elif is_folder(downloadID):
@@ -383,13 +515,63 @@ def download_folder(url, location):
             fileCount += 1
             print(colored('File #{}/{}: '.format(fileCount,total_file_count),'white'),colored('{}'.format(fileInfo['name']),'yellow'))
             try:
-                download_url = service.download(FShare_File_URL+fileInfo['linkcode'])
+                download_file(FShare_File_URL+fileInfo['linkcode'],location,fileInfo['name'],fileInfo.get('size') or fileInfo.get('file_size'))
             except FShareAPIError as e:
                 print(colored('Could not create download link for {}: {}'.format(fileInfo['name'], e),'red'))
                 continue
-            download_file(download_url,location,fileInfo['name'])
+
+def print_download_traffic():
+    try:
+        traffic = service.refresh_download_traffic()
+    except (FShareAPIError, requests.RequestException):
+        return
+    if not traffic:
+        return
+    remaining = traffic.get("remaining") or "unknown"
+    print(colored('Download traffic today: ', 'white'), colored(
+        '{} / {} used ({:.1f}%), {} remaining'.format(
+            traffic["used"],
+            traffic["total"],
+            traffic["percent"],
+            remaining,
+        ),
+        'yellow',
+    ))
     
-def download_file(url, location,filename):
+def wait_for_download_traffic(file_size, force_wait=False):
+    if not getattr(service, "web_download", False) or file_size <= 0:
+        return
+    while force_wait or service.is_download_traffic_low(file_size):
+        remaining = service.download_traffic.get("remaining") if service.download_traffic else "unknown"
+        print(colored(
+            'Fshare daily traffic low ({} left, need {}). Pausing 10 minutes before checking again.'.format(
+                remaining,
+                service._bytes_to_traffic(file_size),
+            ),
+            'yellow',
+        ))
+        time.sleep(TRAFFIC_CHECK_INTERVAL_SECONDS)
+        force_wait = False
+        try:
+            traffic = service.refresh_download_traffic()
+        except (FShareAPIError, requests.RequestException) as e:
+            print(colored('Could not refresh Fshare traffic: {}'.format(e), 'yellow'))
+            continue
+        finally:
+            service.web.close()
+            gc.collect()
+        if traffic:
+            print(colored('Download traffic now: ', 'white'), colored(
+                '{} / {} used ({:.1f}%), {} remaining'.format(
+                    traffic["used"],
+                    traffic["total"],
+                    traffic["percent"],
+                    traffic["remaining"],
+                ),
+                'yellow',
+            ))
+
+def download_file(file_url, location,filename, expected_size=None):
     """
     Download a particular file from with direct link provided from service payload with download bar
     """
@@ -397,43 +579,153 @@ def download_file(url, location,filename):
     local_filename = filename
     local_filename = no_accent_vietnamese(local_filename)
     local_path = location + local_filename
+    expected_size = normalize_file_size(expected_size)
 
-    try:
-        with requests.get(url, stream=True,timeout=(10,30)) as r:
-            try:
+    if expected_size and os.path.exists(local_path):
+        current_size = os.path.getsize(local_path)
+        if current_size == expected_size:
+            print('Local File Existed ! Ignore downloading')
+            return 1
+        if current_size > 0:
+            print('Local file incomplete ! Resume downloading')
+        else:
+            print('Local file incomplete ! Re-download')
+
+    download_session = service.web if getattr(service, "web_download", False) else requests
+
+    while True:
+        download_url = service.download(file_url)
+        local_size = os.path.getsize(local_path) if os.path.exists(local_path) else 0
+        resume_from = local_size if expected_size and local_size < expected_size else 0
+        headers = {
+            "Accept-Encoding": "identity",
+            "Connection": "close",
+            "Range": "bytes={}-".format(resume_from),
+        }
+
+        try:
+            with download_session.get(download_url, stream=True, timeout=(10,30), headers=headers) as r:
+                if resume_from > 0 and r.status_code != 206:
+                    print('Server did not resume partial file. Re-download')
+                    os.remove(local_path)
+                    expected_size = 0
+                    resume_from = 0
+                    r.close()
+                    continue
                 r.raise_for_status()
-                total_size = int(r.headers.get('content-length') or 0)
+                total_size = total_size_from_response(r, resume_from)
+                if total_size:
+                    expected_size = total_size
                 if os.path.exists(local_path):
-                    if total_size > 0 and os.path.getsize(local_path) == total_size:
+                    current_size = os.path.getsize(local_path)
+                    if expected_size > 0 and current_size >= expected_size:
                         print('Local File Existed ! Ignore downloading')
                         return 1
-                    print('Local file incomplete ! Re-download')
-                    os.remove(local_path)
+                    if resume_from == 0 and current_size > 0 and expected_size > 0:
+                        r.close()
+                        continue
+                    if current_size > 0:
+                        print('Local file incomplete ! Resume downloading')
+                    elif resume_from == 0:
+                        print('Local file incomplete ! Re-download')
+                remaining_size = expected_size - resume_from if expected_size else 0
+                if getattr(service, "web_download", False) and service.is_download_traffic_low(remaining_size):
+                    r.close()
+                    wait_for_download_traffic(remaining_size)
+                    continue
                 if (total_size > (2*1024*1024*1024)):
                 #File is greater than 2Gb, use bigger chunk size
-                    download_chunk_size = 2*1024*1024
+                    download_chunk_size = 8*1024*1024
                 else:
-                    download_chunk_size = 1024*1024
-                downloaded_chunk = 0
-                progressbar = tqdm(total=total_size or None,desc="Downloading",ncols=70, unit_scale=True, unit="B")
-                with open(local_path, 'wb') as f:
-                    for chunk in r.iter_content(chunk_size=download_chunk_size):
-                        if chunk: # filter out keep-alive new chunks
-                            f.write(chunk)
-                            f.flush()
-                            progressbar.update(len(chunk))
-                            # progressbar.update(float((downloaded_chunk*(download_chunk_size)/total_size)))
-                            # downloaded_chunk += 1
+                    download_chunk_size = 4*1024*1024
+                downloaded_bytes = 0
+                window_bytes = 0
+                started_at = time.monotonic()
+                window_started_at = started_at
+                progressbar = tqdm(
+                    total=total_size or None,
+                    initial=resume_from if total_size else 0,
+                    desc="Downloading",
+                    ncols=70,
+                    unit_scale=True,
+                    unit="B",
+                )
+                try:
+                    with open(local_path, 'ab' if resume_from > 0 else 'wb') as f:
+                        for chunk in r.iter_content(chunk_size=download_chunk_size):
+                            if chunk: # filter out keep-alive new chunks
+                                f.write(chunk)
+                                chunk_size = len(chunk)
+                                downloaded_bytes += chunk_size
+                                window_bytes += chunk_size
+                                progressbar.update(chunk_size)
+                                now = time.monotonic()
+                                if now - window_started_at >= LOW_SPEED_WINDOW_SECONDS:
+                                    speed = window_bytes / (now - window_started_at)
+                                    elapsed = now - started_at
+                                    if (
+                                        getattr(service, "web_download", False)
+                                        and elapsed >= LOW_SPEED_GRACE_SECONDS
+                                        and speed < LOW_SPEED_THRESHOLD_BYTES
+                                    ):
+                                        print(colored(
+                                            'Download speed too low ({}/s). Pausing and checking Fshare quota every 10 minutes.'.format(
+                                                service._bytes_to_traffic(speed),
+                                            ),
+                                            'yellow',
+                                        ))
+                                        if downloaded_bytes:
+                                            service.apply_download_traffic_usage(downloaded_bytes)
+                                        remaining_size = total_size - os.path.getsize(local_path) if total_size else 0
+                                        wait_for_download_traffic(remaining_size, force_wait=True)
+                                        break
+                                    window_bytes = 0
+                                    window_started_at = now
+                        else:
+                            if getattr(service, "web_download", False):
+                                service.apply_download_traffic_usage(downloaded_bytes)
+                                if service.download_traffic:
+                                    print(colored('Download traffic left: ', 'white'), colored(
+                                        '{} remaining'.format(service.download_traffic["remaining"]),
+                                        'yellow',
+                                    ))
+                            return (location + local_filename)
+                finally:
                     progressbar.close()
-            except HTTPError:
-                print("HTTP Error")
-        return (location + local_filename)
-    except Timeout:
-        print('Please check Internet connection, the request timed out')
-    except RequestException as e:
-        print('Download failed: {}'.format(e))
-        
-        
+                continue
+        except HTTPError:
+            print("HTTP Error")
+            return None
+        except Timeout:
+            print('Please check Internet connection, the request timed out')
+            return None
+        except RequestException as e:
+            print('Download failed: {}'.format(e))
+            return None
+
+def total_size_from_response(response, resume_from):
+    content_range = response.headers.get('content-range')
+    if content_range:
+        match = re.search(r'/(\d+)$', content_range)
+        if match:
+            return int(match.group(1))
+    content_length = int(response.headers.get('content-length') or 0)
+    return resume_from + content_length if resume_from else content_length
+
+def normalize_file_size(value):
+    if value in (None, ""):
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    value = str(value).strip()
+    if value.isdigit():
+        return int(value)
+    match = re.search(r'([\d.]+)\s*([KMGT]?B)', value, re.I)
+    if not match:
+        return 0
+    units = {"B": 1, "KB": 1024, "MB": 1024 ** 2, "GB": 1024 ** 3, "TB": 1024 ** 4}
+    return int(float(match.group(1)) * units[match.group(2).upper()])
+
 def is_folder(url):
     if (url.find(Folder_Indicator)) != -1:
         return True

--- a/fdownload.py
+++ b/fdownload.py
@@ -299,19 +299,20 @@ def download_folder(url, location):
         f.writelines(f"Sub-Folder count: {sub_folder_count} \n")
 
         
-    print(colored("We found {} file(s) in the link, download them now".format(len(folderList)-sub_folder_count),'yellow'))
+    total_file_count = len(folderList)-sub_folder_count
+    print(colored("We found {} file(s) in the link, download them now".format(total_file_count),'yellow'))
     # loop through whole directory and download
     fileCount = 0
     for fileInfo in folderList:
         if not is_folder(fileInfo['furl']):
-            print(colored('File #{}: '.format(fileCount),'white'),colored('{}'.format(fileInfo['name']),'yellow'))
+            fileCount += 1
+            print(colored('File #{}/{}: '.format(fileCount,total_file_count),'white'),colored('{}'.format(fileInfo['name']),'yellow'))
             try:
                 download_url = service.download(FShare_File_URL+fileInfo['linkcode'])
             except FShareAPIError as e:
                 print(colored('Could not create download link for {}: {}'.format(fileInfo['name'], e),'red'))
                 continue
             download_file(download_url,location,fileInfo['name'])
-            fileCount += 1
     
 def download_file(url, location,filename):
     """
@@ -320,38 +321,42 @@ def download_file(url, location,filename):
     # local_filename = url.split('/')[-1]
     local_filename = filename
     local_filename = no_accent_vietnamese(local_filename)
-    if os.path.exists(location + local_filename):
-        print('Local File Existed ! Ignore downloading')
-        return 1
-    else:
-        try:
-            with requests.get(url, stream=True,timeout=(10,30)) as r:
-                try:
-                    r.raise_for_status()
-                    total_size = int(r.headers.get('content-length') or 0)
-                    if (total_size > (2*1024*1024*1024)):
-                    #File is greater than 2Gb, use bigger chunk size
-                        download_chunk_size = 2*1024*1024
-                    else:
-                        download_chunk_size = 1024*1024
-                    downloaded_chunk = 0
-                    progressbar = tqdm(total=total_size or None,desc="Downloading",ncols=70, unit_scale=True, unit="B")
-                    with open(location + local_filename, 'wb') as f:
-                        for chunk in r.iter_content(chunk_size=download_chunk_size): 
-                            if chunk: # filter out keep-alive new chunks
-                                f.write(chunk)
-                                f.flush()
-                                progressbar.update(len(chunk))
-                                # progressbar.update(float((downloaded_chunk*(download_chunk_size)/total_size)))
-                                # downloaded_chunk += 1
-                        progressbar.close()
-                except HTTPError:
-                    print("HTTP Error")
-            return (location + local_filename)
-        except Timeout:
-            print('Please check Internet connection, the request timed out')
-        except RequestException as e:
-            print('Download failed: {}'.format(e))
+    local_path = location + local_filename
+
+    try:
+        with requests.get(url, stream=True,timeout=(10,30)) as r:
+            try:
+                r.raise_for_status()
+                total_size = int(r.headers.get('content-length') or 0)
+                if os.path.exists(local_path):
+                    if total_size > 0 and os.path.getsize(local_path) == total_size:
+                        print('Local File Existed ! Ignore downloading')
+                        return 1
+                    print('Local file incomplete ! Re-download')
+                    os.remove(local_path)
+                if (total_size > (2*1024*1024*1024)):
+                #File is greater than 2Gb, use bigger chunk size
+                    download_chunk_size = 2*1024*1024
+                else:
+                    download_chunk_size = 1024*1024
+                downloaded_chunk = 0
+                progressbar = tqdm(total=total_size or None,desc="Downloading",ncols=70, unit_scale=True, unit="B")
+                with open(local_path, 'wb') as f:
+                    for chunk in r.iter_content(chunk_size=download_chunk_size):
+                        if chunk: # filter out keep-alive new chunks
+                            f.write(chunk)
+                            f.flush()
+                            progressbar.update(len(chunk))
+                            # progressbar.update(float((downloaded_chunk*(download_chunk_size)/total_size)))
+                            # downloaded_chunk += 1
+                    progressbar.close()
+            except HTTPError:
+                print("HTTP Error")
+        return (location + local_filename)
+    except Timeout:
+        print('Please check Internet connection, the request timed out')
+    except RequestException as e:
+        print('Download failed: {}'.format(e))
         
         
 def is_folder(url):

--- a/fdownload.py
+++ b/fdownload.py
@@ -9,6 +9,7 @@ from requests.exceptions import HTTPError, RequestException, Timeout
 
 import configparser
 import httpx
+import json
 import os
 import sys
 import requests
@@ -51,6 +52,8 @@ class FSAPI:
     def __init__(self, email, password):
         self.email = email
         self.password = password
+        self.cookie_file = None
+        self.web_download = False
         self.token = ""
         self.session_id = ""
         self.api = httpx.Client(
@@ -66,7 +69,16 @@ class FSAPI:
             )
         })
 
+    def use_cookie_file(self, cookie_file):
+        self.cookie_file = os.path.expanduser(cookie_file.strip())
+
     def login(self):
+        if self.cookie_file:
+            self._load_web_cookies(self.cookie_file)
+            self._check_web_login()
+            self.web_download = True
+            return {"code": 200, "msg": "Logged in with web cookies"}
+
         payload = {
             "user_email": self.email,
             "password": self.password,
@@ -84,6 +96,9 @@ class FSAPI:
 
     def download(self, url, password=None):
         url = self.check_valid(url)
+        if self.web_download:
+            return self._web_download(url)
+
         payload = {"token": self.token, "url": url}
         if password:
             payload["password"] = password
@@ -142,6 +157,66 @@ class FSAPI:
             message = data.get("message") or data.get("name") or "Metadata lookup failed"
             raise FShareAPIError(f"{message} ({response.status_code})")
         return data
+
+    def _web_download(self, url):
+        try:
+            response = self.web.get(url, timeout=30)
+            response.raise_for_status()
+        except RequestException as e:
+            raise FShareAPIError(f"Could not open Fshare download page: {e}")
+        form = re.search(r'<form id="form-download".*?</form>', response.text, re.S)
+        if not form:
+            raise FShareAPIError("Could not find Fshare download form. Cookie may be expired.")
+        csrf = re.search(r'name="_csrf-app" value="([^"]+)"', form.group(0))
+        linkcode = re.search(r'name="linkcode" value="([^"]+)"', form.group(0))
+        if not csrf or not linkcode:
+            raise FShareAPIError("Could not read Fshare download form fields")
+
+        payload = {
+            "_csrf-app": csrf.group(1),
+            "linkcode": linkcode.group(1),
+            "ushare": "",
+            "withFcode5": "0",
+        }
+        try:
+            response = self.web.post(
+                f"{FShare_Web_URL}/download/get",
+                data=payload,
+                headers={
+                    "X-Requested-With": "XMLHttpRequest",
+                    "Referer": url,
+                },
+                timeout=30,
+            )
+        except RequestException as e:
+            raise FShareAPIError(f"Could not create web download session: {e}")
+        data = self._requests_json(response, "web download session")
+        if "url" not in data:
+            message = data.get("message") or data.get("errors") or data
+            raise FShareAPIError(f"Could not create web download link: {message}")
+        return data["url"]
+
+    def _load_web_cookies(self, cookie_file):
+        with open(cookie_file) as f:
+            data = json.load(f)
+        cookies = data.get("cookies", data) if isinstance(data, dict) else data
+        if not isinstance(cookies, list):
+            raise FShareAPIError("Cookie file must be a JSON list or contain a cookies list")
+        for cookie in cookies:
+            if "name" not in cookie or "value" not in cookie:
+                continue
+            self.web.cookies.set(
+                cookie["name"],
+                cookie["value"],
+                domain=cookie.get("domain"),
+                path=cookie.get("path", "/"),
+            )
+
+    def _check_web_login(self):
+        response = self.web.get(f"{FShare_Web_URL}/account/profile", timeout=30)
+        response.raise_for_status()
+        if "LoginForm[email]" in response.text or "/site/login" in response.url:
+            raise FShareAPIError("Fshare cookie is expired or not logged in")
 
     def _normalize_item(self, item):
         normalized = dict(item)
@@ -370,11 +445,15 @@ def perform_login(login_credential):
     Perform login and return the status True/False
     """    
     global service
-    service = FSAPI(login_credential['username'],login_credential['password'])
+    service = FSAPI(login_credential.get('username',''),login_credential.get('password',''))
+    if login_credential.get('cookie_file'):
+        service.use_cookie_file(login_credential.get('cookie_file'))
     login_status = True
     try:
+        if not service.cookie_file and (not service.email or not service.password):
+            raise FShareAPIError("Missing username/password or cookie_file")
         service.login()
-    except (KeyError, FShareAPIError, httpx.HTTPError):
+    except (KeyError, FShareAPIError, httpx.HTTPError, requests.RequestException, OSError):
         login_status=False
     return login_status
 


### PR DESCRIPTION
## Summary

- Replace the abandoned `get_fshare` metadata calls with a small local Fshare client.
- Fetch file and folder metadata from Fshare's current `/api/v3/files/folder` web endpoint.
- Keep the working HTTP/2 login and `/api/session/download` direct-link flow as fallback.
- Add optional `cookie_file` config for Fshare web-cookie login; when configured, download links are created through Fshare's web `/download/get` flow.
- Add folder-download continue behavior: existing local files are checked against the direct download response `content-length`; exact matches are skipped, size mismatches are re-downloaded at the same item.
- Avoid trusting folder metadata alone for completion checks, because it can falsely mark partial files complete.
- Update setup docs for `httpx[http2]` and cookie-file usage.

## Why

The old `get_fshare` `fileops/get` and `getFolderList` calls can return non-JSON responses now, causing `JSONDecodeError` before any download starts. Login still works, so this keeps the authenticated legacy direct-link flow and swaps out the stale metadata lookup path.

The legacy API direct links can be heavily throttled compared with browser downloads. A logged-in web cookie lets the CLI use the same web download flow as the browser, restoring full-speed links without requiring username/password in `credentials.ini`.

Folder downloads also used to restart link creation from item 1 after interruption. The new direct-length check lets a stopped run continue from the first incomplete file while still avoiding false skips when folder metadata size is missing or wrong.

## Validation

- `python3 -m py_compile fdownload.py`
- `git diff --check`
- Smoke-tested in a temporary virtualenv with real credentials: login succeeded, file metadata loaded, folder metadata loaded, and direct-link creation returned an Fshare download host without downloading the media body.
- Unit-style fake response test: same-size local file skipped only after reading direct `content-length`; partial local file was removed and re-written when direct `content-length` differed.
- Cookie-file smoke test using exported `www.fshare.vn` cookies: cookie-only config logged in, `/download/get` returned a web direct link, and sampled download speed was multiple MiB/s instead of the legacy API link's ~50 KiB/s cap.

## AI disclosure

This change was produced with AI-assisted coding and reviewed/tested locally before opening the pull request.
